### PR TITLE
export `raw` instruction

### DIFF
--- a/src/videocore7/assembler/__init__.pyi
+++ b/src/videocore7/assembler/__init__.pyi
@@ -1007,3 +1007,6 @@ def fmul(dst: Register, src1: Register, src2: float, cond: ALUConditionArg = Non
 def fmul(
     dst: Register, src1: Register, src2: Register, cond: ALUConditionArg = None, sig: SignalArg = None
 ) -> None: ...
+
+# Extra instructions
+def raw(packed_code: int) -> None: ...

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025- Idein Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice (including the next
+# paragraph) shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import hypothesis
+
+from videocore7.assembler import *
+from videocore7.assembler import Assembly, qpu
+from videocore7.driver import Driver
+
+
+@qpu
+def qpu_raw(asm: Assembly, raw_code: int) -> None:
+    raw(raw_code)
+
+
+@hypothesis.given(raw_code=hypothesis.strategies.integers(min_value=0, max_value=0xFFFFFFFFFFFFFFFF))
+def test_raw_embedding_code(raw_code: int) -> None:
+    with Driver() as drv:
+        code = drv.program(qpu_raw, raw_code)
+        assert code == [raw_code]


### PR DESCRIPTION
same as [py-videocore6](https://github.com/Idein/py-videocore6)'s one