### PR TITLE
Fix drm device path

### DIFF
--- a/src/_videocore7/drm_v3d.py
+++ b/src/_videocore7/drm_v3d.py
@@ -49,7 +49,7 @@ class DRM_V3D:  # noqa: N801
     def fd(self: Self) -> int | None:
         return self._fd
 
-    def __init__(self: Self, path: str = "/dev/dri/card0") -> None:
+    def __init__(self: Self, path: str = "/dev/dri/by-path/platform-1002000000.v3d-card") -> None:
         self._fd = os.open(path, os.O_RDWR)
 
     def close(self: Self) -> None:


### PR DESCRIPTION
`/dev/dri/card0` と `/dev/dri/card1` の割り当てによっては以下のようなエラーが発生する。これを回避するため [py-videocore6 と同様](https://github.com/Idein/py-videocore6/blob/1a5fee7ade858305b2f81c78bdd30a3e725f06c2/src/_videocore6/drm_v3d.py#L31) にDRMデバイスパスを修正する。

```
pi@rpios-bookworm-20251110:~/py-videocore7 $ uv run examples/sgemm.py
Traceback (most recent call last):
  File "/home/pi/py-videocore7/examples/sgemm.py", line 317, in <module>
    main()
  File "/home/pi/py-videocore7/examples/sgemm.py", line 313, in main
    sgemm_rnn_naive()
  File "/home/pi/py-videocore7/examples/sgemm.py", line 258, in sgemm_rnn_naive
    with Driver() as drv:
         ^^^^^^^^
  File "/home/pi/py-videocore7/src/_videocore7/driver.py", line 212, in __init__
    raise e
  File "/home/pi/py-videocore7/src/_videocore7/driver.py", line 206, in __init__
    self._memory = Memory(self._drm, total_size)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/py-videocore7/src/_videocore7/driver.py", line 86, in __init__
    raise e
  File "/home/pi/py-videocore7/src/_videocore7/driver.py", line 71, in __init__
    self._handle, self._phyaddr = drm.v3d_create_bo(size)
                                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/py-videocore7/src/_videocore7/drm_v3d.py", line 240, in v3d_create_bo
    ioctl(self._fd, self.IOCTL_V3D_CREATE_BO, st)
OSError: [Errno 22] Invalid argument
```